### PR TITLE
Fixed issue with neo4j 2.1.2 incompatibility

### DIFF
--- a/lib/read.js
+++ b/lib/read.js
@@ -22,11 +22,15 @@ function assembleReadQuery(opts) {
   if (opts.query) {
     query.push(opts.query);
     query.push('WITH ' + opts.varName);
-    if (Array.isArray(opts.otherVars)) 
+    if (Array.isArray(opts.otherVars))
       query.push(',' +opts.otherVars.join(','));
   }
 
-  query.push('MATCH (' + opts.varName + ':' + this.type + ')');
+  if (opts.rootId != null || opts.query != null) {
+    query.push('WHERE (' + opts.varName + ':' + this.type + ')');
+  } else {
+    query.push('MATCH (' + opts.varName + ':' + this.type + ')');
+  }
 
   if (opts.rootId != null) {
     query.unshift('START ' + opts.varName + ' = node({__sm_root})')
@@ -37,7 +41,7 @@ function assembleReadQuery(opts) {
   if (opts.restrictToComp) {
     if (Array.isArray(opts.restrictToComp))
       restrictToComp = _.values(_.pick(this.compositions, opts.restrictToComp))
-    else 
+    else
       restrictToComp = [ this.compositions[opts.restrictToComp] ]
   }
 
@@ -66,12 +70,12 @@ function assembleReadQuery(opts) {
   if (opts.include) {
     Object.keys(opts.include).forEach(function(include) {
       var includeOpts = opts.include[include];
-      
+
       var rel = '-[:`' + includeOpts.rel + '`]-'
       if (includeOpts.direction == 'in') rel = '<' + rel;
       else rel += '>';
 
-      query.push('OPTIONAL MATCH ' + opts.varName + rel + 
+      query.push('OPTIONAL MATCH ' + opts.varName + rel +
                  '(__sm_inc_' + include + ':' + includeOpts.model.type + ')');
     });
   }
@@ -82,7 +86,7 @@ function assembleReadQuery(opts) {
     returnVars.push('COLLECT( __sm_level' + level + ' ) as __sm_level' + level);
     returnVars.push('COLLECT( DISTINCT __sm_r' + level + ' ) as __sm_r' + level);
   }
-  
+
   if (opts.include) {
     Object.keys(opts.include).forEach(function(include) {
       returnVars.push('COLLECT( DISTINCT __sm_inc_' + include + ') as __sm_inc_' + include);
@@ -116,9 +120,9 @@ function coalesceAndCompute(data, opts, callback) {
       async.forEach(_.range(opts.depth -1, -1, -1), function(level, callback) {
         var startNodes = data['__sm_level' + (level - 1)] || [node];
         var endNodes = data['__sm_level' + level];
-      
+
         var rels = data['__sm_r' + level];
-        
+
         async.forEach(rels, function(rel, callback) {
           var start = _.find(startNodes, function(node) {
             return node[self.db.options.id] == rel.start;
@@ -161,7 +165,7 @@ function coalesceAndCompute(data, opts, callback) {
       if (err) return callback(err);
 
       sortComps.call(self, node);
-      if (Array.isArray(opts.otherVars)) 
+      if (Array.isArray(opts.otherVars))
         node = _.extend(node, _.pick(data, opts.otherVars));
       if (opts.restrictToComp && !Array.isArray(opts.restrictToComp))
         callback(null, node[opts.restrictToComp]);
@@ -188,9 +192,9 @@ module.exports = {
     }
 
     if (typeof opts == 'number') opts = { depth: opts };
-    
+
     opts.rootId = node == null ? null : this.db._getId(node);
-    
+
     var query = assembleReadQuery.call(this, opts);
 
     this.db.query(query, opts.params, function(err, data) {

--- a/test/model_test.js
+++ b/test/model_test.js
@@ -10,7 +10,7 @@ describe('Seraph Model', function() {
   var neo;
   var db;
   before(function(done) {
-    seraph({ version: "2.0.3" }, function(err, _db, _neo) {
+    seraph({ version: "2.1.2" }, function(err, _db, _neo) {
       if (err) return done(err);
       db = _db;
       neo = _neo;
@@ -219,7 +219,7 @@ describe('Seraph Model', function() {
     });
 
   });
-  
+
   it('querying should allow other variables and preserve them', function(done) {
     var beer = model(db, 'Beer');
 
@@ -227,8 +227,8 @@ describe('Seraph Model', function() {
       assert(!err);
       beer.save({name:"Galaxy IPA"}, function(err, galaxy) {
         assert(!err);
-        beer.query("match (beer:Beer) where id(beer) in {ids} with beer, {test: true} as stuff", 
-          { ids: [heady.id, galaxy.id] }, {varName: 'beer', otherVars: ['stuff']}, 
+        beer.query("match (beer:Beer) where id(beer) in {ids} with beer, {test: true} as stuff",
+          { ids: [heady.id, galaxy.id] }, {varName: 'beer', otherVars: ['stuff']},
           function(err, results) {
           assert(!err);
           assert(results.length == 2);
@@ -348,7 +348,7 @@ describe('Seraph Model', function() {
               assert(nodes[1].hop.name == 'centennial');
               assert(nodes[0].name == 'beer 1' || nodes[0].name == 'beer 2');
               assert(nodes[1].name == 'beer 1' || nodes[1].name == 'beer 2');
-              
+
               done();
             });
           });


### PR DESCRIPTION
Model reads were throwing `Cannot match on a pattern containing only already bound identifiers` exceptions. This is related to a change as of Neo4j 2.1.2. This pull request updates the query assembler to use `WHERE` instead of `MATCH` where appropriate. Also bumped the test suite to test against 2.1.2.

Apologies for the git churn, just cleaning up some extra whitespace.
