### PR TITLE
adding properties to relationships

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,39 @@ beer.save(pliny, function(err, saved) {
 });
 ```
 
+<a name="composition.relations.properties"/>
+### Relations properties
+
+When you save a composed object, you can specify the relationship properties
+through the `_rel` key.
+
+**example**
+
+```javascript
+
+var pliny = {
+  name: 'Pliny the Elder',
+  brewery: 'Russian River',
+  hops: [
+    { name: 'Columbus', aa: '13.9%', _rel: { quantity: "a bit" } },
+    { name: 'Simcoe', aa: '12.3%', _rel: { quantity: "a lot" } },
+    { name: 'Centennial', aa: '8.0%' }
+  ]
+};
+
+beer.save(pliny, function(err, saved) {
+  console.log(saved);
+  /* -> { brewery: 'Russian River',
+          name: 'Pliny the Elder',
+          id: 11,
+          hops:
+           [ { name: 'Columbus', aa: '13.9%', _rel: { quantity: "a bit" } id: 12 },
+             { name: 'Simcoe', aa: '12.3%', _rel: { quantity: "a lot" }, id: 13 },
+             { name: 'Centennial', aa: '8.0%', id: 14 } ] }
+  */
+});
+```
+
 ### Updating models with compositions
 
 You can use the regular `model.save` function to update a model with 
@@ -632,6 +665,11 @@ Saves or updates an object in the database. The steps for doing this are:
 If `excludeCompositions` is truthy, any composed models attached to `object`
 will not be altered in the database (they will be ignored), and the object which 
 is returned will exclude compositions.
+
+You need to remember that the `_rel` key of any object is a reserved word for
+relations properties (see [Relations properties](#composition.relations.properties))
+and will be stripped from the object when saving, so it's not recommended using
+this name in your model.
 
 <a name="push"/>
 #### `model.push(rootId, compName, object(s), callback(err, savedObject(s)))`

--- a/lib/read.js
+++ b/lib/read.js
@@ -140,6 +140,8 @@ function coalesceAndCompute(data, opts, callback) {
           compute.call(comp.model, end, function(err, end) {
             if (err) return callback(err);
 
+            end._rel = rel.properties;
+
             if (start[comp.name]) {
               if (Array.isArray(start[comp.name])) start[comp.name].push(end);
               else start[comp.name] = [ start[comp.name], end ];

--- a/lib/write.js
+++ b/lib/write.js
@@ -53,6 +53,9 @@ function reassembleFromGraph(graph, data) {
   function _reassembleFromGraph(node, object) {
     node.children.forEach(function(child) {
       var node =  _reassembleFromGraph(child, data[child.name]);
+
+      if (data['__rel_' + child.name]) node._rel = data['__rel_' + child.name].properties;
+
       if (!object[child.comp.name]) 
         object[child.comp.name] = child.comp.many ? [node] : node;
       else if (!Array.isArray(object[child.comp.name]))
@@ -163,6 +166,13 @@ var compose = {
       // set props
       var props = node.props;
       if (props[self.db.options.id]) props = _.omit(props, self.db.options.id);
+      
+      if (node.comp) {
+        params['__rel_' + node.name] = props._rel || {};
+        statements.push('__rel_' + node.name + '={__rel_' + node.name + '}');
+      }
+      props = _.omit(props, '_rel');
+
       params[node.name] = props;
       statements.push(node.name + '={' + node.name + '}');
 
@@ -182,7 +192,7 @@ var compose = {
     function getRels(node) {
       var rels = [];
       node.children.forEach(function(childNode) {
-        rels.push(node.name + '-[:' + childNode.comp.rel + ']->' + childNode.name);
+        rels.push(node.name + '-[__rel_' + childNode.name + ':' + childNode.comp.rel + ']->' + childNode.name);
         rels.push.apply(rels, getRels(childNode));
       });
       return rels;
@@ -193,7 +203,9 @@ var compose = {
   // creates a WITH clause that carries over all of the the current relevant
   // variables
   continuation: function (graph) {
-    return 'WITH ' + _.pluck(graph.allNodes, 'name').join(',');
+    return 'WITH ' + _.map(graph.allNodes, function (node) {
+      return node.name + (node.comp ? ',__rel_' + node.name : '');
+    });
   },
   stripRedundantCompositions: function (graph, opts) {
     if (_.isEmpty(this.compositions) || opts.keepRedundancy) return '';
@@ -211,7 +223,9 @@ var compose = {
     ].join(' ');
   },
   return: function (graph, opts) {
-    return 'RETURN ' + _.pluck(graph.allNodes, 'name');
+    return 'RETURN ' + _.map(graph.allNodes, function (node) {
+      return node.name + (node.comp ? ',__rel_' + node.name : '');
+    });
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.6.18",
   "description": "thin model layer for seraph/neo4j",
   "main": "lib/model.js",
+  "repository": "git@github.com:brikteknologier/seraph-model.git",
   "scripts": {
     "test": "./node_modules/mocha/bin/mocha -R spec -t 360000"
   },


### PR DESCRIPTION
fixes #64

I just want to check with you guy if generating the relation identifier in cypher by prefixing the node name with `rel_` is the right way to go, or if you prefer to use some kind of name generator like [this one](https://github.com/brikteknologier/seraph-model/blob/master/lib/write.js#L15-L22).
I think it might overlap if you have a model named `whatever` which is related to another model, AND a third model named `rel_whatever`, all involved in the same query.

If that's fine with you, I'll keep going :
- [x] merge relationships properties while read the related models
- [ ] ~~ability to filter on relationships properties~~ it looks like this can already be done with `model.query`
- [x] add tests
- [x] update README.md