### PR TITLE
saveComposition [Error: Invalid root node - 0]

### DIFF
--- a/lib/write.js
+++ b/lib/write.js
@@ -328,7 +328,7 @@ module.exports = {
     if (!Array.isArray(objects)) objects = [objects];
 
     var rootId = this.db._getId(root);
-    if (!rootId) return callback(new Error("Invalid root node - " + root));
+    if (rootId == null) return callback(new Error("Invalid root node - " + root));
 
     var self = this;
     var shell = {};


### PR DESCRIPTION
during saveComposition on a new install of neo4j I got an

`[Error: Invalid root node - 0]` error.

I'm not sure if neo4j ids start with 0, but I think so (the object in question has id of 0)

This PR should make it so saveComposition works on root id of 0.