### PR TITLE
Upgrade async dependency to a version that works in strict mode.

### DIFF
--- a/lib/read.js
+++ b/lib/read.js
@@ -1,7 +1,7 @@
 var transformComps = require('./transform-composed-nodes'),
     async = require('async'),
     _ = require('underscore'),
-    compositionRelationCypherList = require('./composition-relation-cypher-list')
+    compositionRelationCypherList = require('./composition-relation-cypher-list'),
     sortComps = require('./sort-compositions');
 
 function assembleReadQuery(opts) {
@@ -135,7 +135,7 @@ function coalesceAndCompute(data, opts, callback) {
           });
 
           var comp = opts.compMapping[level][rel.type];
-          
+
           var compute = self.compute;
           if (opts.computeLevels != null && level >= opts.computeLevels) compute = emptyCompute;
           compute.call(comp.model, end, function(err, end) {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "async": "~0.1.22",
+    "async": "~0.2.9",
     "moment": "~2.0.0",
     "underscore": "~1.5.0"
   },


### PR DESCRIPTION
Fix for #98.

I tried to upgrade to the most recent version of `async` but it appears to have a different API. So I set it to 0.2.9, which is the same version that seraph uses, which plays fine with strict mode.

I also added a comma in `lib/read.js` that fixes a syntax error, at least on my node version.