### PR TITLE
Add parentheses around node when constructing read query

### DIFF
--- a/lib/read.js
+++ b/lib/read.js
@@ -64,7 +64,7 @@ function assembleReadQuery(opts) {
     var rels = compositionRelationCypherList(comps);
     var start = level ? '__sm_level' + (level - 1) : opts.varName;
     query.push('OPTIONAL MATCH');
-    query.push(start + '-[__sm_r' + level + ':' + rels + ']->(__sm_level' + level + ')');
+    query.push('(' + start + ')-[__sm_r' + level + ':' + rels + ']->(__sm_level' + level + ')');
   }
 
   if (opts.include) {


### PR DESCRIPTION
A very tiny issue breaking compatibility with neo4j 3.0.